### PR TITLE
Add python versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10"]
     
     steps:
     - name: Check-out repository
@@ -21,6 +21,13 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Load pip cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip
+        restore-keys: ${{ runner.os }}-pip
 
     - name: Install Poetry
       uses: snok/install-poetry@v1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     
     steps:
     - name: Check-out repository

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     
     steps:
     - name: Check-out repository

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
     
     steps:
     - name: Check-out repository

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,10 +38,10 @@ jobs:
     - name: Install package
       run: poetry install
 
-    - name: Run tests
+    - name: Test with pytest
       run: |
-      source .venv/bin/activate
-      poetry run pytest tests/ --cov=clean_text_rhoni --cov-report=xml
+          source .venv/bin/activate
+          poetry run pytest tests/ --cov=clean_text_rhoni --cov-report=xml
 
     - name: Build documentation
       run: poetry run make html --directory docs/

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,22 +14,34 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     
     steps:
+    - name: Check-out repository
+      uses: actions/checkout@v3
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Check-out repository
-      uses: actions/checkout@v3
-
-    - name: Install poetry
+    - name: Install Poetry
       uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v3
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
     - name: Install package
       run: poetry install
 
-    - name: Test with pytest
-      run: poetry run pytest tests/ --cov=clean_text_rhoni --cov-report=xml
+    - name: Run tests
+      run: |
+      source .venv/bin/activate
+      poetry run pytest tests/ --cov=clean_text_rhoni --cov-report=xml
 
     - name: Build documentation
       run: poetry run make html --directory docs/

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,9 +1,6 @@
-# Name of the workflow
 name: ci-cd
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,15 +11,16 @@ on:
 
 jobs:
   ci:
-    # Set up operating system
     runs-on: ubuntu-latest
-
-    # Define job steps
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    
     steps:
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
 
     - name: Check-out repository
       uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+poetry.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
 
 # Configuration
 python:
-  version: 3.x
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
 
 # Configuration
 python:
-  version: 3.8
+  version: 3.10
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,17 +1,18 @@
 # Required
 version: 2
 
-# Build documentation in the "docs/" directory with Sphinx
+# Build from the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
-# Image to use
+# Set OS and python version
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
-# Configuration
+# Python configuration
 python:
-  version: 3.10
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
 
 # Configuration
 python:
-  version: 3.9
+  version: 3.x
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,11 @@ To install the package for development you will have to:
     $ git checkout -b name-of-your-bugfix-or-feature
     ```
 
+### Commiting changes
+
+To commit your changes, please follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) conventions.
+
+
 ### Contributions on code
 
 1. Code is located in `src/clean_text_rhoni` folder.
@@ -76,6 +81,9 @@ If you add new features:
 * add the corresponding test in `test/` folder.
 * modify or add documentation if necessary
 
+
+### Testing the package
+
 This package uses [`pytest`](https://docs.pytest.org/en/7.4.x/) for testing.
 To run the package’s tests, you must be in the root of the package and run:
 
@@ -83,8 +91,35 @@ To run the package’s tests, you must be in the root of the package and run:
 pytest tests/
 ```
 
-3. To commit your changes, please follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) conventions.
+**Testing the package on different python versions**
 
+This package was developed on Ubuntu 22.04 and tested on python 3.8, 3.9, 3.10 and 3.11.
+If you add new features, you have to test that the package is still working under the different versions.
+The easiest way to do this, is by using [`Docker Compose`](https://docs.docker.com/compose/). The necessary `Dockerfiles` and the `docker-compose.yml` file are included in the package.
+To run it, you'll have to:
+
+1. Install [`docker`](https://docs.docker.com/engine/install/) in your computer.
+2. Install [`docker compose`](https://docs.docker.com/compose/install/) in your computer.
+3. Build the docker images defined in `docker-compose.yml`.
+Open a terminal and go to the root of the package. Then run:
+
+```bash
+docker compose build
+```
+4. Start the services:
+
+```bash
+docker compose up
+```
+
+As result you will have to see that code coverage is calculated for each python version, and that every process is exited with code 0. This is, the processes were completed successfully without encountering any errors.
+
+You will see something similar to:
+
+```bash
+clean_text_rhoni-py38-1 exited with code 0
+```
+for each python version that is being tested.
 
 ### Contributions on documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  py38:
+    build:
+      context: .
+      dockerfile: ./dockerfiles/Dockerfile.py38
+  py39:
+    build:
+      context: .
+      dockerfile: ./dockerfiles/Dockerfile.py39
+  py310:
+    build:
+      context: .
+      dockerfile: ./dockerfiles/Dockerfile.py310
+  py311:
+    build:
+      context: .
+      dockerfile: ./dockerfiles/Dockerfile.py311

--- a/dockerfiles/Dockerfile.py310
+++ b/dockerfiles/Dockerfile.py310
@@ -1,0 +1,20 @@
+FROM python:3.10-slim-buster
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update
+
+RUN pip install --upgrade pip
+RUN pip install poetry
+
+RUN mkdir /clean_text_rhoni
+WORKDIR /clean_text_rhoni
+COPY . /clean_text_rhoni
+
+ENV PYTHONPATH=${PYTHONPATH}:${PWD}
+RUN poetry config virtualenvs.create true
+
+RUN poetry install
+
+CMD [ "poetry", "run", "pytest", "tests/", "--cov=clean_text_rhoni", "--cov-report=xml" ]

--- a/dockerfiles/Dockerfile.py311
+++ b/dockerfiles/Dockerfile.py311
@@ -1,0 +1,20 @@
+FROM python:3.11-slim-buster
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update
+
+RUN pip install --upgrade pip
+RUN pip install poetry
+
+RUN mkdir /clean_text_rhoni
+WORKDIR /clean_text_rhoni
+COPY . /clean_text_rhoni
+
+ENV PYTHONPATH=${PYTHONPATH}:${PWD}
+RUN poetry config virtualenvs.create true
+
+RUN poetry install
+
+CMD [ "poetry", "run", "pytest", "tests/", "--cov=clean_text_rhoni", "--cov-report=xml" ]

--- a/dockerfiles/Dockerfile.py38
+++ b/dockerfiles/Dockerfile.py38
@@ -1,0 +1,20 @@
+FROM python:3.8-slim-buster
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update
+
+RUN pip install --upgrade pip
+RUN pip install poetry
+
+RUN mkdir /clean_text_rhoni
+WORKDIR /clean_text_rhoni
+COPY . /clean_text_rhoni
+
+ENV PYTHONPATH=${PYTHONPATH}:${PWD}
+RUN poetry config virtualenvs.create true
+
+RUN poetry install
+
+CMD [ "poetry", "run", "pytest", "tests/", "--cov=clean_text_rhoni", "--cov-report=xml" ]

--- a/dockerfiles/Dockerfile.py39
+++ b/dockerfiles/Dockerfile.py39
@@ -1,0 +1,20 @@
+FROM python:3.9-slim-buster
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update
+
+RUN pip install --upgrade pip
+RUN pip install poetry
+
+RUN mkdir /clean_text_rhoni
+WORKDIR /clean_text_rhoni
+COPY . /clean_text_rhoni
+
+ENV PYTHONPATH=${PYTHONPATH}:${PWD}
+RUN poetry config virtualenvs.create true
+
+RUN poetry install
+
+CMD [ "poetry", "run", "pytest", "tests/", "--cov=clean_text_rhoni", "--cov-report=xml" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,14 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.7"
+python = ">=3.8"
 
 [tool.poetry.dev-dependencies]
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.4.0"
 pytest-cov = ">=4.1.0"
-myst-nb = {version = ">=0.17.2", python = ">=3.7,<4.0"}
+myst-nb = {version = ">=0.17.2", python = ">=3.8,<4.0"}
 sphinx-autoapi = ">=2.1.1"
 sphinx-rtd-theme = ">=1.2.2"
 python-semantic-release = ">=8.0.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,14 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.7"
 
 [tool.poetry.dev-dependencies]
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.4.0"
 pytest-cov = ">=4.1.0"
-myst-nb = {version = ">=0.17.2", python = ">=3.9,<4.0"}
+myst-nb = {version = ">=0.17.2", python = ">=3.7,<4.0"}
 sphinx-autoapi = ">=2.1.1"
 sphinx-rtd-theme = ">=1.2.2"
 python-semantic-release = ">=8.0.8"


### PR DESCRIPTION
The compatibility of the package for different python versions was developed in this PR.

- Python versions were added from 3.8 to 3.11 to run tests for all versions by using CI from GitHub Actions.
- Dockerfiles for each version and a docker-compose.yml were added to install the package and run the tests for the 4 versions.